### PR TITLE
fix(upload): use current signed file contracts

### DIFF
--- a/Maliev.ContactService.Api/Controllers/ContactsController.cs
+++ b/Maliev.ContactService.Api/Controllers/ContactsController.cs
@@ -41,15 +41,18 @@ public class ContactsController : ControllerBase
     /// Submit a contact form message
     /// </summary>
     /// <param name="request">The contact form data</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
     /// <returns>The created contact message</returns>
     [HttpPost]
     [AllowAnonymous]
     [EnableRateLimiting(RateLimitPolicies.Public)]
-    public async Task<ActionResult<ContactMessageDto>> CreateContactMessage(CreateContactMessageRequest request)
+    public async Task<ActionResult<ContactMessageDto>> CreateContactMessage(
+        CreateContactMessageRequest request,
+        CancellationToken cancellationToken)
     {
         // Let ExceptionHandlingMiddleware handle exceptions for proper status codes
         // (409 for DuplicateInquiryException, 503 for CountryServiceException, etc.)
-        var contact = await _contactService.CreateContactMessageAsync(request);
+        var contact = await _contactService.CreateContactMessageAsync(request, cancellationToken);
 
         return CreatedAtAction(
             nameof(GetContactMessage),
@@ -188,15 +191,19 @@ public class ContactsController : ControllerBase
     /// </summary>
     /// <param name="id">Contact message ID</param>
     /// <param name="fileId">File ID</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
     /// <returns>No content if successful</returns>
     [HttpDelete("{id}/files/{fileId}")]
     [RequirePermission(ContactPermissions.Contacts.Delete)]
     [EnableRateLimiting(RateLimitPolicies.Api)]
-    public async Task<IActionResult> DeleteContactFile(int id, int fileId)
+    public async Task<IActionResult> DeleteContactFile(
+        int id,
+        int fileId,
+        CancellationToken cancellationToken)
     {
         try
         {
-            await _contactService.DeleteContactFileAsync(id, fileId);
+            await _contactService.DeleteContactFileAsync(id, fileId, cancellationToken);
             return NoContent();
         }
         catch (Maliev.ContactService.Application.Exceptions.NotFoundException)
@@ -210,11 +217,15 @@ public class ContactsController : ControllerBase
     /// </summary>
     /// <param name="id">Contact message ID</param>
     /// <param name="fileId">File ID</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
     /// <returns>The file content</returns>
     [HttpGet("{id}/files/{fileId}/download")]
     [RequirePermission(ContactPermissions.Contacts.Read)]
     [EnableRateLimiting(RateLimitPolicies.Api)]
-    public async Task<IActionResult> DownloadContactFile(int id, int fileId)
+    public async Task<IActionResult> DownloadContactFile(
+        int id,
+        int fileId,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -225,12 +236,18 @@ public class ContactsController : ControllerBase
                 return NotFound();
             }
 
-            var downloadResponse = await _uploadService.DownloadFileAsync(file.UploadServiceFileId);
+            var downloadResponse = await _uploadService.DownloadFileAsync(
+                file.UploadServiceFileId,
+                cancellationToken);
             return File(downloadResponse.Content, downloadResponse.ContentType, downloadResponse.FileName);
         }
         catch (Maliev.ContactService.Application.Exceptions.NotFoundException)
         {
             return NotFound();
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/Maliev.ContactService.Application/Interfaces/IContactService.cs
+++ b/Maliev.ContactService.Application/Interfaces/IContactService.cs
@@ -5,12 +5,17 @@ namespace Maliev.ContactService.Application.Interfaces;
 
 public interface IContactService
 {
-    Task<ContactMessageDto> CreateContactMessageAsync(CreateContactMessageRequest request);
+    Task<ContactMessageDto> CreateContactMessageAsync(
+        CreateContactMessageRequest request,
+        CancellationToken cancellationToken = default);
     Task<ContactMessageDto?> GetContactMessageByIdAsync(int id);
     Task<IEnumerable<ContactMessageDto>> GetContactMessagesAsync(int page = 1, int pageSize = 20, ContactStatus? status = null, ContactType? contactType = null, string? email = null);
     Task<ContactMessageDto> UpdateContactStatusAsync(int id, UpdateContactStatusRequest request);
     Task DeleteContactMessageAsync(int id);
     Task<IEnumerable<ContactFileDto>> GetContactFilesAsync(int contactId);
     Task<ContactFileDto?> GetContactFileByIdAsync(int contactId, int fileId);
-    Task DeleteContactFileAsync(int contactId, int fileId);
+    Task DeleteContactFileAsync(
+        int contactId,
+        int fileId,
+        CancellationToken cancellationToken = default);
 }

--- a/Maliev.ContactService.Application/Interfaces/IUploadServiceClient.cs
+++ b/Maliev.ContactService.Application/Interfaces/IUploadServiceClient.cs
@@ -2,9 +2,16 @@ namespace Maliev.ContactService.Application.Interfaces;
 
 public interface IUploadServiceClient
 {
-    Task<UploadResponse> UploadFileAsync(string objectName, byte[] content, string contentType, string fileName);
-    Task DeleteFileAsync(string fileId);
-    Task<DownloadResponse> DownloadFileAsync(string fileId);
+    Task<UploadResponse> UploadFileAsync(
+        string objectName,
+        byte[] content,
+        string contentType,
+        string fileName,
+        CancellationToken cancellationToken = default);
+
+    Task DeleteFileAsync(string fileId, CancellationToken cancellationToken = default);
+
+    Task<DownloadResponse> DownloadFileAsync(string fileId, CancellationToken cancellationToken = default);
 }
 
 public record UploadResponse(string FileId, long FileSize);

--- a/Maliev.ContactService.Application/Services/ContactService.cs
+++ b/Maliev.ContactService.Application/Services/ContactService.cs
@@ -51,7 +51,9 @@ public class ContactService : IContactService
     }
 
     /// <inheritdoc/>
-    public async Task<ContactMessageDto> CreateContactMessageAsync(CreateContactMessageRequest request)
+    public async Task<ContactMessageDto> CreateContactMessageAsync(
+        CreateContactMessageRequest request,
+        CancellationToken cancellationToken = default)
     {
         if (request == null) throw new ArgumentNullException(nameof(request));
 
@@ -59,7 +61,9 @@ public class ContactService : IContactService
         var strategy = _context.Database.CreateExecutionStrategy();
 
         var isDuplicate = await strategy.ExecuteAsync(async () =>
-            await _context.ContactMessages.AnyAsync(c => c.Email == request.Email && c.CreatedAt > sixtySecondsAgo));
+            await _context.ContactMessages.AnyAsync(
+                c => c.Email == request.Email && c.CreatedAt > sixtySecondsAgo,
+                cancellationToken));
 
         if (isDuplicate)
         {
@@ -77,7 +81,7 @@ public class ContactService : IContactService
 
         var createdMessage = await strategy.ExecuteAsync(async () =>
         {
-            using var transaction = await _context.Database.BeginTransactionAsync();
+            using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
             try
             {
                 var contactMessage = new ContactMessage
@@ -97,7 +101,7 @@ public class ContactService : IContactService
                 };
 
                 _context.ContactMessages.Add(contactMessage);
-                await _context.SaveChangesAsync();
+                await _context.SaveChangesAsync(cancellationToken);
 
                 if (request.Files.Any())
                 {
@@ -107,7 +111,12 @@ public class ContactService : IContactService
                         try
                         {
                             var objectName = $"contacts/{contactMessage.Id}/{Guid.NewGuid()}_{fileRequest.FileName}";
-                            var uploadResponse = await _uploadService.UploadFileAsync(objectName, fileRequest.FileContent, fileRequest.ContentType ?? "application/octet-stream", fileRequest.FileName);
+                            var uploadResponse = await _uploadService.UploadFileAsync(
+                                objectName,
+                                fileRequest.FileContent,
+                                fileRequest.ContentType ?? "application/octet-stream",
+                                fileRequest.FileName,
+                                cancellationToken);
 
                             var contactFile = new ContactFile
                             {
@@ -121,6 +130,10 @@ public class ContactService : IContactService
                             };
                             uploadedFiles.Add(contactFile);
                         }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            throw;
+                        }
                         catch (Exception ex)
                         {
                             _logger.LogError(ex, "Failed to upload file {FileName} for contact {ContactId}. Rejecting contact submission.", fileRequest.FileName, contactMessage.Id);
@@ -131,14 +144,19 @@ public class ContactService : IContactService
                     if (uploadedFiles.Any())
                     {
                         _context.ContactFiles.AddRange(uploadedFiles);
-                        await _context.SaveChangesAsync();
+                        await _context.SaveChangesAsync(cancellationToken);
                     }
                 }
 
-                await transaction.CommitAsync();
+                await transaction.CommitAsync(cancellationToken);
 
                 _logger.LogInformation("Contact inquiry created successfully. ID={ContactId}", contactMessage.Id);
                 return contactMessage.ToDto();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                await transaction.RollbackAsync(CancellationToken.None);
+                throw;
             }
             catch (Exception ex)
             {
@@ -262,16 +280,25 @@ public class ContactService : IContactService
     }
 
     /// <inheritdoc/>
-    public async Task DeleteContactFileAsync(int contactId, int fileId)
+    public async Task DeleteContactFileAsync(
+        int contactId,
+        int fileId,
+        CancellationToken cancellationToken = default)
     {
-        var file = await _context.ContactFiles.FirstOrDefaultAsync(f => f.Id == fileId && f.ContactMessageId == contactId);
+        var file = await _context.ContactFiles.FirstOrDefaultAsync(
+            f => f.Id == fileId && f.ContactMessageId == contactId,
+            cancellationToken);
         if (file == null) throw new NotFoundException($"Contact file with id {fileId} for contact {contactId} not found");
 
         if (!string.IsNullOrEmpty(file.UploadServiceFileId))
         {
             try
             {
-                await _uploadService.DeleteFileAsync(file.UploadServiceFileId);
+                await _uploadService.DeleteFileAsync(file.UploadServiceFileId, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {
@@ -280,7 +307,7 @@ public class ContactService : IContactService
         }
 
         _context.ContactFiles.Remove(file);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
 
         await InvalidateListCacheAsync();
         await _cache.RemoveAsync($"contact_message_{contactId}");

--- a/Maliev.ContactService.Infrastructure/DependencyInjection.cs
+++ b/Maliev.ContactService.Infrastructure/DependencyInjection.cs
@@ -34,6 +34,15 @@ public static class DependencyInjection
         .AddServiceDiscovery()
         .AddHttpMessageHandler<ServiceAccountAuthenticationHandler>();
 
+        services.AddHttpClient(UploadServiceClient.StorageHttpClientName, client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(15);
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            AllowAutoRedirect = false
+        });
+
         services.AddHttpClient<ICountryServiceClient, CountryServiceClient>(client =>
         {
             client.BaseAddress = new Uri(

--- a/Maliev.ContactService.Infrastructure/DependencyInjection.cs
+++ b/Maliev.ContactService.Infrastructure/DependencyInjection.cs
@@ -40,7 +40,8 @@ public static class DependencyInjection
         })
         .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
         {
-            AllowAutoRedirect = false
+            AllowAutoRedirect = false,
+            UseCookies = false
         });
 
         services.AddHttpClient<ICountryServiceClient, CountryServiceClient>(client =>

--- a/Maliev.ContactService.Infrastructure/ExternalServices/UploadServiceClient.cs
+++ b/Maliev.ContactService.Infrastructure/ExternalServices/UploadServiceClient.cs
@@ -1,18 +1,50 @@
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Maliev.ContactService.Application.Interfaces;
+using Microsoft.Extensions.Configuration;
 
 namespace Maliev.ContactService.Infrastructure.ExternalServices;
 
+/// <summary>
+/// Calls UploadService for file metadata operations and transfers bytes through signed storage URLs.
+/// </summary>
 public class UploadServiceClient : IUploadServiceClient
 {
-    private readonly HttpClient _httpClient;
+    /// <summary>
+    /// The named client used only for unsigned storage transfers.
+    /// </summary>
+    public const string StorageHttpClientName = "ContactService.StorageTransfer";
 
-    public UploadServiceClient(HttpClient httpClient)
+    private const int SignedUrlExpirationMinutes = 5;
+    private readonly bool _allowInsecureStorageUrls;
+    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    /// <summary>
+    /// Initializes a new UploadService client.
+    /// </summary>
+    /// <param name="httpClient">The authenticated UploadService client.</param>
+    /// <param name="httpClientFactory">Factory for the isolated storage-transfer client.</param>
+    /// <param name="configuration">Application configuration.</param>
+    public UploadServiceClient(
+        HttpClient httpClient,
+        IHttpClientFactory httpClientFactory,
+        IConfiguration configuration)
     {
         _httpClient = httpClient;
+        _httpClientFactory = httpClientFactory;
+        _allowInsecureStorageUrls = configuration.GetValue<bool>(
+            "ExternalServices:UploadService:AllowInsecureStorageUrls");
     }
 
-    public async Task<UploadResponse> UploadFileAsync(string objectName, byte[] content, string contentType, string fileName)
+    /// <inheritdoc/>
+    public async Task<UploadResponse> UploadFileAsync(
+        string objectName,
+        byte[] content,
+        string contentType,
+        string fileName,
+        CancellationToken cancellationToken = default)
     {
         var initiateRequest = new InitiateResumableUploadRequest(
             Path: objectName,
@@ -22,47 +54,134 @@ public class UploadServiceClient : IUploadServiceClient
             TotalSize: content.LongLength,
             Overwrite: true);
 
-        var initiateResponse = await _httpClient.PostAsJsonAsync("/upload/v1/uploads/resumable", initiateRequest);
+        using var initiateResponse = await _httpClient.PostAsJsonAsync(
+            "/upload/v1/uploads/resumable",
+            initiateRequest,
+            cancellationToken);
         initiateResponse.EnsureSuccessStatusCode();
 
-        var session = await initiateResponse.Content.ReadFromJsonAsync<InitiateResumableUploadResponse>()
-            ?? throw new InvalidOperationException("Upload service returned null resumable session");
+        var session = await initiateResponse.Content.ReadFromJsonAsync<InitiateResumableUploadResponse>(
+            cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException("Upload service returned an empty resumable session.");
+        var sessionUri = ValidateStorageUri(session.SessionUri, "resumable upload session");
 
-        using var gcsClient = new HttpClient();
         using var uploadContent = new ByteArrayContent(content);
-        uploadContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+        uploadContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
         uploadContent.Headers.ContentLength = content.LongLength;
-        uploadContent.Headers.ContentRange = new System.Net.Http.Headers.ContentRangeHeaderValue(0, content.LongLength - 1, content.LongLength);
+        uploadContent.Headers.ContentRange = new ContentRangeHeaderValue(
+            0,
+            content.LongLength - 1,
+            content.LongLength);
 
-        var gcsResponse = await gcsClient.PutAsync(session.SessionUri, uploadContent);
-        gcsResponse.EnsureSuccessStatusCode();
+        var storageClient = _httpClientFactory.CreateClient(StorageHttpClientName);
+        using var storageResponse = await storageClient.PutAsync(sessionUri, uploadContent, cancellationToken);
+        storageResponse.EnsureSuccessStatusCode();
 
-        var response = await _httpClient.PostAsJsonAsync($"/upload/v1/uploads/resumable/{session.UploadId}/complete", new { });
-        response.EnsureSuccessStatusCode();
+        var escapedUploadId = Uri.EscapeDataString(session.UploadId);
+        using var completeResponse = await _httpClient.PostAsJsonAsync(
+            $"/upload/v1/uploads/resumable/{escapedUploadId}/complete",
+            new { },
+            cancellationToken);
+        completeResponse.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<UploadServiceResponse>();
-        return new UploadResponse(result!.UploadId, result.FileSize);
+        var result = await completeResponse.Content.ReadFromJsonAsync<UploadServiceResponse>(
+            cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException("Upload service returned an empty completion response.");
+        return new UploadResponse(result.UploadId, result.FileSize);
     }
 
-    public async Task DeleteFileAsync(string fileId)
+    /// <inheritdoc/>
+    public async Task DeleteFileAsync(string fileId, CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.DeleteAsync($"/v1/files/{fileId}");
+        var escapedFileId = Uri.EscapeDataString(fileId);
+        using var response = await _httpClient.DeleteAsync(
+            $"/upload/v1/files/{escapedFileId}",
+            cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task<DownloadResponse> DownloadFileAsync(string fileId)
+    /// <inheritdoc/>
+    public async Task<DownloadResponse> DownloadFileAsync(
+        string fileId,
+        CancellationToken cancellationToken = default)
     {
-        var response = await _httpClient.GetAsync($"/v1/files/{fileId}/download");
-        response.EnsureSuccessStatusCode();
+        var escapedFileId = Uri.EscapeDataString(fileId);
+        using var signedUrlResponse = await _httpClient.PostAsJsonAsync(
+            $"/upload/v1/files/{escapedFileId}/signed-url",
+            new GenerateSignedUrlRequest(SignedUrlExpirationMinutes),
+            cancellationToken);
+        signedUrlResponse.EnsureSuccessStatusCode();
 
-        var content = await response.Content.ReadAsByteArrayAsync();
-        var contentType = response.Content.Headers.ContentType?.MediaType ?? "application/octet-stream";
-        var fileName = response.Content.Headers.ContentDisposition?.FileName ?? "file";
+        SignedUrlResponse signedUrl;
+        try
+        {
+            signedUrl = await signedUrlResponse.Content.ReadFromJsonAsync<SignedUrlResponse>(
+                cancellationToken: cancellationToken)
+                ?? throw new InvalidOperationException("Upload service returned an empty signed URL response.");
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("Upload service returned a malformed signed URL response.", ex);
+        }
+        var downloadUri = ValidateStorageUri(signedUrl.SignedUrl, "signed download URL");
 
-        return new DownloadResponse(content, contentType, fileName);
+        var storageClient = _httpClientFactory.CreateClient(StorageHttpClientName);
+        using var downloadResponse = await storageClient.GetAsync(
+            downloadUri,
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken);
+        downloadResponse.EnsureSuccessStatusCode();
+
+        var bytes = await downloadResponse.Content.ReadAsByteArrayAsync(cancellationToken);
+        var contentType = downloadResponse.Content.Headers.ContentType?.MediaType
+            ?? "application/octet-stream";
+        var fileName = GetSafeFileName(downloadResponse, signedUrl.StoragePath);
+
+        return new DownloadResponse(bytes, contentType, fileName);
     }
 
-    private record UploadServiceResponse(string UploadId, long FileSize);
+    private string ValidateStorageUri(string? value, string description)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttps
+                && !(_allowInsecureStorageUrls
+                    && uri.Scheme == Uri.UriSchemeHttp
+                    && uri.IsLoopback)))
+        {
+            throw new InvalidOperationException(
+                $"Upload service returned an invalid or insecure {description}.");
+        }
+
+        return uri.AbsoluteUri;
+    }
+
+    private static string GetSafeFileName(HttpResponseMessage response, string? storagePath)
+    {
+        var headerFileName = response.Content.Headers.ContentDisposition?.FileNameStar
+            ?? response.Content.Headers.ContentDisposition?.FileName;
+        var candidate = string.IsNullOrWhiteSpace(headerFileName)
+            ? Path.GetFileName((storagePath ?? string.Empty).Replace('\\', '/'))
+            : headerFileName.Trim('"');
+        candidate = Path.GetFileName(candidate.Replace('\\', '/'));
+
+        return string.IsNullOrWhiteSpace(candidate) || IsUnsafeFileName(candidate)
+            ? "file"
+            : candidate;
+    }
+
+    private static bool IsUnsafeFileName(string value) =>
+        value.Any(char.IsControl)
+        || value.IndexOfAny(['/', '\\', ':', '*', '?', '"', '<', '>', '|']) >= 0;
+
+    private sealed record UploadServiceResponse(string UploadId, long FileSize);
+
+    private sealed record GenerateSignedUrlRequest(int ExpirationMinutes);
+
+    private sealed record SignedUrlResponse(
+        string? SignedUrl,
+        DateTime ExpiresAt,
+        string? UploadId,
+        string? StoragePath);
 
     private sealed record InitiateResumableUploadRequest(
         string Path,

--- a/Maliev.ContactService.Infrastructure/ExternalServices/UploadServiceClient.cs
+++ b/Maliev.ContactService.Infrastructure/ExternalServices/UploadServiceClient.cs
@@ -16,6 +16,7 @@ public class UploadServiceClient : IUploadServiceClient
     /// </summary>
     public const string StorageHttpClientName = "ContactService.StorageTransfer";
 
+    private const string ServiceName = "contact-service";
     private const int SignedUrlExpirationMinutes = 5;
     private readonly bool _allowInsecureStorageUrls;
     private readonly HttpClient _httpClient;
@@ -49,7 +50,7 @@ public class UploadServiceClient : IUploadServiceClient
         var initiateRequest = new InitiateResumableUploadRequest(
             Path: objectName,
             FileName: fileName,
-            ServiceName: "ContactService",
+            ServiceName: ServiceName,
             ContentType: contentType,
             TotalSize: content.LongLength,
             Overwrite: true);
@@ -60,9 +61,16 @@ public class UploadServiceClient : IUploadServiceClient
             cancellationToken);
         initiateResponse.EnsureSuccessStatusCode();
 
-        var session = await initiateResponse.Content.ReadFromJsonAsync<InitiateResumableUploadResponse>(
-            cancellationToken: cancellationToken)
-            ?? throw new InvalidOperationException("Upload service returned an empty resumable session.");
+        var session = await ReadRequiredJsonAsync<InitiateResumableUploadResponse>(
+            initiateResponse.Content,
+            "resumable session",
+            cancellationToken);
+        if (string.IsNullOrWhiteSpace(session.UploadId))
+        {
+            throw new InvalidOperationException(
+                "Upload service returned an incomplete resumable session response.");
+        }
+
         var sessionUri = ValidateStorageUri(session.SessionUri, "resumable upload session");
 
         using var uploadContent = new ByteArrayContent(content);
@@ -84,9 +92,16 @@ public class UploadServiceClient : IUploadServiceClient
             cancellationToken);
         completeResponse.EnsureSuccessStatusCode();
 
-        var result = await completeResponse.Content.ReadFromJsonAsync<UploadServiceResponse>(
-            cancellationToken: cancellationToken)
-            ?? throw new InvalidOperationException("Upload service returned an empty completion response.");
+        var result = await ReadRequiredJsonAsync<UploadServiceResponse>(
+            completeResponse.Content,
+            "completion",
+            cancellationToken);
+        if (string.IsNullOrWhiteSpace(result.UploadId) || result.FileSize < 0)
+        {
+            throw new InvalidOperationException(
+                "Upload service returned an incomplete completion response.");
+        }
+
         return new UploadResponse(result.UploadId, result.FileSize);
     }
 
@@ -112,17 +127,10 @@ public class UploadServiceClient : IUploadServiceClient
             cancellationToken);
         signedUrlResponse.EnsureSuccessStatusCode();
 
-        SignedUrlResponse signedUrl;
-        try
-        {
-            signedUrl = await signedUrlResponse.Content.ReadFromJsonAsync<SignedUrlResponse>(
-                cancellationToken: cancellationToken)
-                ?? throw new InvalidOperationException("Upload service returned an empty signed URL response.");
-        }
-        catch (JsonException ex)
-        {
-            throw new InvalidOperationException("Upload service returned a malformed signed URL response.", ex);
-        }
+        var signedUrl = await ReadRequiredJsonAsync<SignedUrlResponse>(
+            signedUrlResponse.Content,
+            "signed URL",
+            cancellationToken);
         var downloadUri = ValidateStorageUri(signedUrl.SignedUrl, "signed download URL");
 
         var storageClient = _httpClientFactory.CreateClient(StorageHttpClientName);
@@ -143,6 +151,7 @@ public class UploadServiceClient : IUploadServiceClient
     private string ValidateStorageUri(string? value, string description)
     {
         if (!Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || !string.IsNullOrEmpty(uri.UserInfo)
             || (uri.Scheme != Uri.UriSchemeHttps
                 && !(_allowInsecureStorageUrls
                     && uri.Scheme == Uri.UriSchemeHttp
@@ -153,6 +162,25 @@ public class UploadServiceClient : IUploadServiceClient
         }
 
         return uri.AbsoluteUri;
+    }
+
+    private static async Task<T> ReadRequiredJsonAsync<T>(
+        HttpContent content,
+        string responseDescription,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        try
+        {
+            return await content.ReadFromJsonAsync<T>(cancellationToken: cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Upload service returned an empty {responseDescription} response.");
+        }
+        catch (JsonException)
+        {
+            throw new InvalidOperationException(
+                $"Upload service returned a malformed {responseDescription} response.");
+        }
     }
 
     private static string GetSafeFileName(HttpResponseMessage response, string? storagePath)
@@ -173,7 +201,7 @@ public class UploadServiceClient : IUploadServiceClient
         value.Any(char.IsControl)
         || value.IndexOfAny(['/', '\\', ':', '*', '?', '"', '<', '>', '|']) >= 0;
 
-    private sealed record UploadServiceResponse(string UploadId, long FileSize);
+    private sealed record UploadServiceResponse(string? UploadId, long FileSize);
 
     private sealed record GenerateSignedUrlRequest(int ExpirationMinutes);
 
@@ -192,8 +220,8 @@ public class UploadServiceClient : IUploadServiceClient
         bool Overwrite);
 
     private sealed record InitiateResumableUploadResponse(
-        string UploadId,
-        string SessionUri,
+        string? UploadId,
+        string? SessionUri,
         DateTime ExpiresAt,
         long TotalSize);
 }

--- a/Maliev.ContactService.Tests/Services/ExceptionAndEntityTests.cs
+++ b/Maliev.ContactService.Tests/Services/ExceptionAndEntityTests.cs
@@ -167,6 +167,25 @@ public class InfrastructureServiceTests
 
         Assert.Contains("client.Timeout = TimeSpan.FromSeconds(5);", source, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void DependencyInjection_StorageTransferClient_DisablesRedirectsAndCookies()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            "Maliev.ContactService.Infrastructure",
+            "DependencyInjection.cs"));
+
+        Assert.True(File.Exists(sourcePath), $"Could not find source file: {sourcePath}");
+        var source = File.ReadAllText(sourcePath);
+
+        Assert.Contains("AllowAutoRedirect = false", source, StringComparison.Ordinal);
+        Assert.Contains("UseCookies = false", source, StringComparison.Ordinal);
+    }
 }
 
 public class EntityTests

--- a/Maliev.ContactService.Tests/Services/MockUploadServiceClient.cs
+++ b/Maliev.ContactService.Tests/Services/MockUploadServiceClient.cs
@@ -6,8 +6,14 @@ public class MockUploadServiceClient : IUploadServiceClient
 {
     public static bool ThrowOnUpload { get; set; }
 
-    public Task<UploadResponse> UploadFileAsync(string objectName, byte[] content, string contentType, string fileName)
+    public Task<UploadResponse> UploadFileAsync(
+        string objectName,
+        byte[] content,
+        string contentType,
+        string fileName,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (ThrowOnUpload)
         {
             throw new InvalidOperationException("Mock upload failure.");
@@ -16,13 +22,15 @@ public class MockUploadServiceClient : IUploadServiceClient
         return Task.FromResult(new UploadResponse("mock-file-id", content.Length));
     }
 
-    public Task DeleteFileAsync(string fileId)
+    public Task DeleteFileAsync(string fileId, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         return Task.CompletedTask;
     }
 
-    public Task<DownloadResponse> DownloadFileAsync(string fileId)
+    public Task<DownloadResponse> DownloadFileAsync(string fileId, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var content = System.Text.Encoding.UTF8.GetBytes("Mock file content");
         return Task.FromResult(new DownloadResponse(content, "text/plain", "mock.txt"));
     }

--- a/Maliev.ContactService.Tests/Services/UploadServiceClientTests.cs
+++ b/Maliev.ContactService.Tests/Services/UploadServiceClientTests.cs
@@ -9,6 +9,202 @@ namespace Maliev.ContactService.Tests.Services;
 public sealed class UploadServiceClientTests
 {
     [Fact]
+    public async Task UploadFileAsync_ValidFile_UsesCanonicalContractsAndIsolatedStorageClient()
+    {
+        var serviceCall = 0;
+        var serviceHandler = new RecordingHandler(request =>
+        {
+            serviceCall++;
+            if (serviceCall == 1)
+            {
+                Assert.Equal(HttpMethod.Post, request.Method);
+                Assert.Equal("/upload/v1/uploads/resumable", request.RequestUri!.PathAndQuery);
+                Assert.Equal(
+                    "{\"path\":\"contacts/7/report.pdf\",\"fileName\":\"report.pdf\",\"serviceName\":\"contact-service\",\"contentType\":\"application/pdf\",\"totalSize\":3,\"overwrite\":true}",
+                    request.Body);
+                Assert.Equal("Bearer", request.Authorization?.Scheme);
+                return JsonResponse("""
+                    {"uploadId":"upload/42","sessionUri":"https://storage.example/upload/session","expiresAt":"2026-07-16T21:00:00Z","totalSize":3}
+                    """);
+            }
+
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("/upload/v1/uploads/resumable/upload%2F42/complete", request.RequestUri!.PathAndQuery);
+            Assert.Equal("{}", request.Body);
+            Assert.Equal("Bearer", request.Authorization?.Scheme);
+            return JsonResponse("{" + "\"uploadId\":\"upload/42\",\"fileSize\":3}");
+        });
+        var storageHandler = new RecordingHandler(request =>
+        {
+            Assert.Equal(HttpMethod.Put, request.Method);
+            Assert.Equal("https://storage.example/upload/session", request.RequestUri!.AbsoluteUri);
+            Assert.Equal("abc", request.Body);
+            Assert.Equal("application/pdf", request.ContentType);
+            Assert.Equal("bytes 0-2/3", request.ContentRange);
+            Assert.Null(request.Authorization);
+            Assert.Empty(request.Cookies);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var result = await client.UploadFileAsync(
+            "contacts/7/report.pdf",
+            Encoding.UTF8.GetBytes("abc"),
+            "application/pdf",
+            "report.pdf",
+            CancellationToken.None);
+
+        Assert.Equal("upload/42", result.FileId);
+        Assert.Equal(3, result.FileSize);
+        Assert.Equal(2, serviceHandler.Requests.Count);
+        Assert.Single(storageHandler.Requests);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task UploadFileAsync_InitiateFails_ThrowsWithoutStorageOrCompletion(HttpStatusCode statusCode)
+    {
+        var serviceHandler = new RecordingHandler(_ => new HttpResponseMessage(statusCode));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => UploadAsync(client));
+
+        Assert.Equal(statusCode, exception.StatusCode);
+        Assert.Single(serviceHandler.Requests);
+        Assert.Empty(storageHandler.Requests);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-json")]
+    [InlineData("null")]
+    [InlineData("{}")]
+    public async Task UploadFileAsync_InitiateMalformedOrEmpty_ThrowsStableContractFailure(string json)
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse(json));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => UploadAsync(client));
+
+        if (!string.IsNullOrEmpty(json))
+        {
+            Assert.DoesNotContain(json, exception.Message, StringComparison.Ordinal);
+        }
+        Assert.Null(exception.InnerException);
+        Assert.Empty(storageHandler.Requests);
+    }
+
+    [Theory]
+    [InlineData("not-a-url", false)]
+    [InlineData("file:///secret", false)]
+    [InlineData("https://user:password@storage.example/session", false)]
+    [InlineData("http://storage.example/session", true)]
+    [InlineData("http://127.0.0.1:4443/session", false)]
+    public async Task UploadFileAsync_UnsafeSessionUri_EnforcesExactPolicy(
+        string sessionUri,
+        bool allowInsecureStorageUrls)
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse($$"""
+            {"uploadId":"upload-42","sessionUri":"{{sessionUri}}","expiresAt":"2026-07-16T21:00:00Z","totalSize":3}
+            """));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(serviceHandler, storageHandler, allowInsecureStorageUrls);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => UploadAsync(client));
+
+        Assert.Empty(storageHandler.Requests);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_ConfiguredLoopbackHttpSession_AllowsDevelopmentOverride()
+    {
+        var serviceCall = 0;
+        var serviceHandler = new RecordingHandler(_ => ++serviceCall == 1
+            ? JsonResponse("""
+                {"uploadId":"upload-42","sessionUri":"http://127.0.0.1:4443/session","expiresAt":"2026-07-16T21:00:00Z","totalSize":3}
+                """)
+            : JsonResponse("{\"uploadId\":\"upload-42\",\"fileSize\":3}"));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(serviceHandler, storageHandler, allowInsecureStorageUrls: true);
+
+        var result = await UploadAsync(client);
+
+        Assert.Equal("upload-42", result.FileId);
+        Assert.Single(storageHandler.Requests);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_StoragePutFails_DoesNotComplete()
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse("""
+            {"uploadId":"upload-42","sessionUri":"https://storage.example/session","expiresAt":"2026-07-16T21:00:00Z","totalSize":3}
+            """));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => UploadAsync(client));
+
+        Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+        Assert.Single(serviceHandler.Requests);
+        Assert.Single(storageHandler.Requests);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_CompleteFails_ThrowsStableHttpRequestException()
+    {
+        var serviceCall = 0;
+        var serviceHandler = new RecordingHandler(_ => ++serviceCall == 1
+            ? JsonResponse("""
+                {"uploadId":"upload-42","sessionUri":"https://storage.example/session","expiresAt":"2026-07-16T21:00:00Z","totalSize":3}
+                """)
+            : new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var client = CreateClient(serviceHandler, new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => UploadAsync(client));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, exception.StatusCode);
+        Assert.Equal(2, serviceHandler.Requests.Count);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-json")]
+    [InlineData("null")]
+    [InlineData("{}")]
+    public async Task UploadFileAsync_CompleteMalformedOrEmpty_ThrowsStableContractFailure(string json)
+    {
+        var serviceCall = 0;
+        var serviceHandler = new RecordingHandler(_ => ++serviceCall == 1
+            ? JsonResponse("""
+                {"uploadId":"upload-42","sessionUri":"https://storage.example/session","expiresAt":"2026-07-16T21:00:00Z","totalSize":3}
+                """)
+            : JsonResponse(json));
+        var client = CreateClient(serviceHandler, new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => UploadAsync(client));
+
+        if (!string.IsNullOrEmpty(json))
+        {
+            Assert.DoesNotContain(json, exception.Message, StringComparison.Ordinal);
+        }
+        Assert.Null(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task UploadFileAsync_CancelledRequest_PropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var serviceHandler = new RecordingHandler(_ => throw new InvalidOperationException("Handler should not execute."));
+        var client = CreateClient(serviceHandler, new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => UploadAsync(client, cancellation.Token));
+    }
+
+    [Fact]
     public async Task DeleteFileAsync_ReservedUploadId_UsesEscapedCurrentRouteAndPropagatesCancellation()
     {
         using var cancellation = new CancellationTokenSource();
@@ -173,6 +369,7 @@ public sealed class UploadServiceClientTests
             BaseAddress = new Uri("https://upload.example")
         };
         serviceClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "service-token");
+        serviceClient.DefaultRequestHeaders.Add("Cookie", "contact-session=secret");
 
         var storageClient = new HttpClient(storageHandler);
         var factory = new StubHttpClientFactory(storageClient);
@@ -190,6 +387,16 @@ public sealed class UploadServiceClientTests
     {
         Content = new StringContent(json, Encoding.UTF8, "application/json")
     };
+
+    private static Task<Maliev.ContactService.Application.Interfaces.UploadResponse> UploadAsync(
+        UploadServiceClient client,
+        CancellationToken cancellationToken = default) =>
+        client.UploadFileAsync(
+            "contacts/file.txt",
+            Encoding.UTF8.GetBytes("abc"),
+            "text/plain",
+            "file.txt",
+            cancellationToken);
 
     private sealed class StubHttpClientFactory(HttpClient client) : IHttpClientFactory
     {
@@ -216,6 +423,9 @@ public sealed class UploadServiceClientTests
                 request.RequestUri,
                 request.Content?.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult(),
                 request.Headers.Authorization,
+                request.Headers.TryGetValues("Cookie", out var cookieValues) ? cookieValues.ToArray() : [],
+                request.Content?.Headers.ContentType?.MediaType,
+                request.Content?.Headers.ContentRange?.ToString(),
                 cancellationToken);
             Requests.Add(recorded);
             return Task.FromResult(responder(recorded));
@@ -227,5 +437,8 @@ public sealed class UploadServiceClientTests
         Uri? RequestUri,
         string? Body,
         AuthenticationHeaderValue? Authorization,
+        IReadOnlyList<string> Cookies,
+        string? ContentType,
+        string? ContentRange,
         CancellationToken CancellationToken);
 }

--- a/Maliev.ContactService.Tests/Services/UploadServiceClientTests.cs
+++ b/Maliev.ContactService.Tests/Services/UploadServiceClientTests.cs
@@ -1,0 +1,231 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Maliev.ContactService.Infrastructure.ExternalServices;
+using Microsoft.Extensions.Configuration;
+
+namespace Maliev.ContactService.Tests.Services;
+
+public sealed class UploadServiceClientTests
+{
+    [Fact]
+    public async Task DeleteFileAsync_ReservedUploadId_UsesEscapedCurrentRouteAndPropagatesCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var serviceHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.NoContent));
+        var client = CreateClient(serviceHandler, new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+        await client.DeleteFileAsync("folder/id with space", cancellation.Token);
+
+        var request = Assert.Single(serviceHandler.Requests);
+        Assert.Equal(HttpMethod.Delete, request.Method);
+        Assert.Equal("/upload/v1/files/folder%2Fid%20with%20space", request.RequestUri!.PathAndQuery);
+        Assert.True(request.CancellationToken.CanBeCanceled);
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_ValidSignedUrl_PostsBoundedRequestThenDownloadsWithoutAuthorization()
+    {
+        var serviceHandler = new RecordingHandler(request =>
+        {
+            Assert.Equal(HttpMethod.Post, request.Method);
+            Assert.Equal("/upload/v1/files/file%2F42/signed-url", request.RequestUri!.PathAndQuery);
+            Assert.Equal("{\"expirationMinutes\":5}", request.Body);
+            Assert.Equal("Bearer", request.Authorization?.Scheme);
+            return JsonResponse("""
+                {"signedUrl":"https://storage.example/files/file-42","expiresAt":"2026-07-16T01:00:00Z","uploadId":"file/42","storagePath":"contacts/7/report.pdf"}
+                """);
+        });
+        var storageHandler = new RecordingHandler(request =>
+        {
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.Equal("https://storage.example/files/file-42", request.RequestUri!.AbsoluteUri);
+            Assert.Null(request.Authorization);
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3])
+            };
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/pdf");
+            return response;
+        });
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var result = await client.DownloadFileAsync("file/42", CancellationToken.None);
+
+        Assert.Equal([1, 2, 3], result.Content);
+        Assert.Equal("application/pdf", result.ContentType);
+        Assert.Equal("report.pdf", result.FileName);
+        Assert.Single(serviceHandler.Requests);
+        Assert.Single(storageHandler.Requests);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task DownloadFileAsync_SignedUrlRequestFails_ThrowsWithoutCallingStorage(HttpStatusCode statusCode)
+    {
+        var serviceHandler = new RecordingHandler(_ => new HttpResponseMessage(statusCode));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.DownloadFileAsync("file-42", CancellationToken.None));
+
+        Assert.Equal(statusCode, exception.StatusCode);
+        Assert.Empty(storageHandler.Requests);
+    }
+
+    [Theory]
+    [InlineData("not-json")]
+    [InlineData("{}")]
+    [InlineData("{\"signedUrl\":\"not-a-url\",\"storagePath\":\"contacts/file.txt\"}")]
+    [InlineData("{\"signedUrl\":\"http://storage.example/file\",\"storagePath\":\"contacts/file.txt\"}")]
+    [InlineData("{\"signedUrl\":\"file:///secrets.txt\",\"storagePath\":\"contacts/file.txt\"}")]
+    public async Task DownloadFileAsync_MalformedOrUnsafeSignedUrl_RejectsWithoutCallingStorage(string json)
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse(json));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK));
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.DownloadFileAsync("file-42", CancellationToken.None));
+
+        Assert.Empty(storageHandler.Requests);
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_StorageFailure_ThrowsStableHttpRequestException()
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse("""
+            {"signedUrl":"https://storage.example/file","expiresAt":"2026-07-16T01:00:00Z","uploadId":"file-42","storagePath":"contacts/file.txt"}
+            """));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.DownloadFileAsync("file-42", CancellationToken.None));
+
+        Assert.Equal(HttpStatusCode.BadGateway, exception.StatusCode);
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_UnsafeContentDisposition_UsesSafeFallbackName()
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse("""
+            {"signedUrl":"https://storage.example/file","expiresAt":"2026-07-16T01:00:00Z","uploadId":"file-42","storagePath":"contacts/safe-name.txt"}
+            """));
+        var storageHandler = new RecordingHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1])
+            };
+            response.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "../unsafe:name.txt"
+            };
+            return response;
+        });
+        var client = CreateClient(serviceHandler, storageHandler);
+
+        var result = await client.DownloadFileAsync("file-42", CancellationToken.None);
+
+        Assert.Equal("file", result.FileName);
+        Assert.Equal("application/octet-stream", result.ContentType);
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_ConfiguredLocalHttpUrl_AllowsExplicitDevelopmentOverride()
+    {
+        var serviceHandler = new RecordingHandler(_ => JsonResponse("""
+            {"signedUrl":"http://127.0.0.1:4443/file","expiresAt":"2026-07-16T01:00:00Z","uploadId":"file-42","storagePath":"contacts/file.txt"}
+            """));
+        var storageHandler = new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new ByteArrayContent([1])
+        });
+        var client = CreateClient(serviceHandler, storageHandler, allowInsecureStorageUrls: true);
+
+        var result = await client.DownloadFileAsync("file-42", CancellationToken.None);
+
+        Assert.Equal([1], result.Content);
+    }
+
+    [Fact]
+    public async Task DownloadFileAsync_CancelledRequest_PropagatesCancellationToken()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var serviceHandler = new RecordingHandler(_ => throw new InvalidOperationException("Handler should not execute."));
+        var client = CreateClient(serviceHandler, new RecordingHandler(_ => new HttpResponseMessage(HttpStatusCode.OK)));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => client.DownloadFileAsync("file-42", cancellation.Token));
+    }
+
+    private static UploadServiceClient CreateClient(
+        RecordingHandler serviceHandler,
+        RecordingHandler storageHandler,
+        bool allowInsecureStorageUrls = false)
+    {
+        var serviceClient = new HttpClient(serviceHandler)
+        {
+            BaseAddress = new Uri("https://upload.example")
+        };
+        serviceClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "service-token");
+
+        var storageClient = new HttpClient(storageHandler);
+        var factory = new StubHttpClientFactory(storageClient);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ExternalServices:UploadService:AllowInsecureStorageUrls"] = allowInsecureStorageUrls.ToString()
+            })
+            .Build();
+
+        return new UploadServiceClient(serviceClient, factory, configuration);
+    }
+
+    private static HttpResponseMessage JsonResponse(string json) => new(HttpStatusCode.OK)
+    {
+        Content = new StringContent(json, Encoding.UTF8, "application/json")
+    };
+
+    private sealed class StubHttpClientFactory(HttpClient client) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+        {
+            Assert.Equal(UploadServiceClient.StorageHttpClientName, name);
+            return client;
+        }
+    }
+
+    private sealed class RecordingHandler(Func<RecordedRequest, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Task.FromCanceled<HttpResponseMessage>(cancellationToken);
+            }
+
+            var recorded = new RecordedRequest(
+                request.Method,
+                request.RequestUri,
+                request.Content?.ReadAsStringAsync(cancellationToken).GetAwaiter().GetResult(),
+                request.Headers.Authorization,
+                cancellationToken);
+            Requests.Add(recorded);
+            return Task.FromResult(responder(recorded));
+        }
+    }
+
+    private sealed record RecordedRequest(
+        HttpMethod Method,
+        Uri? RequestUri,
+        string? Body,
+        AuthenticationHeaderValue? Authorization,
+        CancellationToken CancellationToken);
+}


### PR DESCRIPTION
## Summary
- replace obsolete UploadService delete/download calls with current v1 delete and signed-URL contracts
- use canonical contact-service identity for resumable upload initiation
- retrieve signed storage URLs through a dedicated credential- and cookie-free client with redirects disabled
- enforce bounded URL/response validation, cancellation, and stable dependency failures
- add complete initiate -> storage PUT -> complete and signed-download contract coverage

## Security boundary
The Contact bearer token is used only for UploadService APIs. It is never forwarded to signed storage. HTTP is rejected except an explicit loopback-only test/local override.

## Validation
- focused upload/DI tests: 34/34
- non-container tests: 52/52
- Release build: 0 warnings/errors
- format and dependency audit: green
- full container suite earlier blocked by Docker Hub pull timeout; no code assertion failed
- independent review findings fixed and follow-up approved

Tracks MALIEV-Co-Ltd/maliev-ops#78
Depends on MALIEV-Co-Ltd/maliev-ops#77 for managed-workload scoped Upload authorization.
No deployment or GitOps enablement.