### PR TITLE
feat(auth): exchange ContactService workload tokens

### DIFF
--- a/Maliev.ContactService.Api/Program.cs
+++ b/Maliev.ContactService.Api/Program.cs
@@ -48,6 +48,7 @@ try
 
     // JWT Authentication (tests override via PostConfigureAll with dynamic RSA keys)
     builder.AddJwtAuthentication();
+    builder.AddAuthServiceTokenExchange("ContactService");
 
     // --- Authorization & Permissions ---
     builder.Services.AddPermissionAuthorization();
@@ -75,7 +76,6 @@ try
     builder.AddStandardRateLimiting(); // Memory-optimized for low-spec nodes
 
     // IAM Registration Service
-    builder.AddIAMServiceClient("contact");
     builder.Services.AddIAMRegistration<ContactIAMRegistrationService>("contact");
 
     builder.Services.AddControllers();

--- a/Maliev.ContactService.Infrastructure/DependencyInjection.cs
+++ b/Maliev.ContactService.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,4 @@
 using Maliev.Aspire.ServiceDefaults.Authorization;
-using Maliev.Aspire.ServiceDefaults.IAM;
 using Maliev.ContactService.Application.Interfaces;
 using Maliev.ContactService.Infrastructure.BackgroundServices;
 using Maliev.ContactService.Infrastructure.ExternalServices;
@@ -7,6 +6,7 @@ using Maliev.ContactService.Infrastructure.Metrics;
 using Maliev.ContactService.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Maliev.ContactService.Infrastructure;
 
@@ -32,7 +32,7 @@ public static class DependencyInjection
             client.Timeout = TimeSpan.FromSeconds(5);
         })
         .AddServiceDiscovery()
-        .AddHttpMessageHandler<ServiceAccountAuthenticationHandler>();
+        .AddAuthServiceAuthentication();
 
         services.AddHttpClient(UploadServiceClient.StorageHttpClientName, client =>
         {
@@ -52,7 +52,7 @@ public static class DependencyInjection
                 ?? "https+http://CountryService");
         })
         .AddServiceDiscovery()
-        .AddHttpMessageHandler<ServiceAccountAuthenticationHandler>();
+        .AddAuthServiceAuthentication();
 
         return services;
     }

--- a/Maliev.ContactService.Tests/Integration/Infrastructure/IntegrationTestWebAppFactory.cs
+++ b/Maliev.ContactService.Tests/Integration/Infrastructure/IntegrationTestWebAppFactory.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System.Security.Cryptography;
+using System.Text;
 using Testcontainers.PostgreSql;
 using Testcontainers.RabbitMq;
 using Testcontainers.Redis;
@@ -96,7 +97,8 @@ public class IntegrationTestWebAppFactory : WebApplicationFactory<Program>, IAsy
                 ["ServiceAuthentication:ClientId"] = "service-contact-service",
                 ["ServiceAuthentication:ClientSecret"] = "contact-test-secret-with-at-least-32-bytes",
                 ["Services:AuthService:BaseUrl"] = "http://127.0.0.1:5000",
-                ["Jwt:PublicKey"] = Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo()),
+                ["Jwt:PublicKey"] = Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes(rsa.ExportSubjectPublicKeyInfoPem())),
                 ["Jwt:Issuer"] = "https://api.maliev.com",
                 ["Jwt:Audience"] = "https://api.maliev.com"
             })

--- a/Maliev.ContactService.Tests/Integration/Infrastructure/IntegrationTestWebAppFactory.cs
+++ b/Maliev.ContactService.Tests/Integration/Infrastructure/IntegrationTestWebAppFactory.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Security.Cryptography;
 using Testcontainers.PostgreSql;
 using Testcontainers.RabbitMq;
 using Testcontainers.Redis;
@@ -83,13 +84,21 @@ public class IntegrationTestWebAppFactory : WebApplicationFactory<Program>, IAsy
     {
         builder.UseEnvironment("Testing");
 
+        using var rsa = RSA.Create(2048);
+
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>
             {
                 ["ConnectionStrings:ContactDbContext"] = ConnectionString,
                 ["ConnectionStrings:rabbitmq"] = RabbitMqConnectionString,
                 ["ConnectionStrings:redis"] = RedisConnectionString,
-                ["CORS:AllowedOrigins:0"] = "https://localhost:5001"
+                ["CORS:AllowedOrigins:0"] = "https://localhost:5001",
+                ["ServiceAuthentication:ClientId"] = "service-contact-service",
+                ["ServiceAuthentication:ClientSecret"] = "contact-test-secret-with-at-least-32-bytes",
+                ["Services:AuthService:BaseUrl"] = "http://127.0.0.1:5000",
+                ["Jwt:PublicKey"] = Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo()),
+                ["Jwt:Issuer"] = "https://api.maliev.com",
+                ["Jwt:Audience"] = "https://api.maliev.com"
             })
             .Build();
 #pragma warning restore CS0618

--- a/Maliev.ContactService.Tests/Services/ServiceAuthenticationWiringTests.cs
+++ b/Maliev.ContactService.Tests/Services/ServiceAuthenticationWiringTests.cs
@@ -1,0 +1,144 @@
+using Maliev.Aspire.ServiceDefaults.IAM;
+using Maliev.ContactService.Application.Interfaces;
+using Maliev.ContactService.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+
+namespace Maliev.ContactService.Tests.Services;
+
+public sealed class ServiceAuthenticationWiringTests
+{
+    private const string ExpectedToken = "centrally-issued-contact-token";
+
+    [Fact]
+    public void Program_RegistersExactContactProcessIdentityWithoutLegacySigner()
+    {
+        var source = ReadRepositoryFile("Maliev.ContactService.Api", "Program.cs");
+
+        Assert.Contains("builder.AddAuthServiceTokenExchange(\"ContactService\");", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddIAMServiceClient", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AuthServiceExchange_UsesExactContactProcessIdentity()
+    {
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = "Testing"
+        });
+        AddExchangeConfiguration(builder.Configuration);
+
+        builder.AddAuthServiceTokenExchange("ContactService");
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var identity = provider.GetRequiredService<ServiceProcessIdentity>();
+
+        Assert.Equal("ContactService", identity.ServiceName);
+        Assert.Null(provider.GetService<IServiceAccountTokenProvider>());
+    }
+
+    [Theory]
+    [InlineData(typeof(IUploadServiceClient))]
+    [InlineData(typeof(ICountryServiceClient))]
+    public async Task DownstreamClient_UsesAuthServiceExchangeHandler(Type clientType)
+    {
+        var services = new ServiceCollection();
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ExternalServices:UploadService"] = "https://upload.test",
+                ["ExternalServices:CountryService"] = "https://country.test"
+            })
+            .Build();
+        var capture = new AuthorizationCaptureHandler();
+
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(configuration);
+        services.AddSingleton<IAuthServiceTokenProvider>(new StubTokenProvider());
+        services.AddTransient<AuthServiceTokenExchangeHandler>();
+        services.AddSingleton<IHttpMessageHandlerBuilderFilter>(new CapturingPrimaryHandlerFilter(capture));
+        services.AddInfrastructure(configuration);
+
+        await using var provider = services.BuildServiceProvider();
+        var typedClient = provider.GetRequiredService(clientType);
+        var clientField = typedClient.GetType().GetField("_httpClient", BindingFlags.Instance | BindingFlags.NonPublic);
+        var client = Assert.IsType<HttpClient>(clientField?.GetValue(typedClient));
+
+        using var response = await client.GetAsync("https://boundary.test/authentication-probe", CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(new AuthenticationHeaderValue("Bearer", ExpectedToken), capture.Authorization);
+    }
+
+    private static void AddExchangeConfiguration(ConfigurationManager configuration)
+    {
+        using var rsa = System.Security.Cryptography.RSA.Create(2048);
+        configuration["ServiceAuthentication:ClientId"] = "service-contact-service";
+        configuration["ServiceAuthentication:ClientSecret"] = "contact-test-secret-with-at-least-32-bytes";
+        configuration["Services:AuthService:BaseUrl"] = "http://127.0.0.1:5000";
+        configuration["Jwt:PublicKey"] = Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo());
+        configuration["Jwt:Issuer"] = "https://api.maliev.com";
+        configuration["Jwt:Audience"] = "https://api.maliev.com";
+    }
+
+    private static string ReadRepositoryFile(params string[] segments)
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            Path.Combine(segments)));
+
+        Assert.True(File.Exists(path), $"Could not find source file: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private sealed class StubTokenProvider : IAuthServiceTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(ExpectedToken);
+    }
+
+    private sealed class AuthorizationCaptureHandler : HttpMessageHandler
+    {
+        public AuthenticationHeaderValue? Authorization { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Authorization = request.Headers.Authorization;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private sealed class CapturingPrimaryHandlerFilter(HttpMessageHandler primaryHandler)
+        : IHttpMessageHandlerBuilderFilter
+    {
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next) => builder =>
+        {
+            next(builder);
+            for (var index = builder.AdditionalHandlers.Count - 1; index >= 0; index--)
+            {
+                if (builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ServiceDiscovery",
+                        StringComparison.Ordinal) == true ||
+                    builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ResolvingHttpDelegatingHandler",
+                        StringComparison.Ordinal) == true)
+                {
+                    builder.AdditionalHandlers.RemoveAt(index);
+                }
+            }
+
+            builder.PrimaryHandler = primaryHandler;
+        };
+    }
+}

--- a/Maliev.ContactService.Tests/Services/ServiceAuthenticationWiringTests.cs
+++ b/Maliev.ContactService.Tests/Services/ServiceAuthenticationWiringTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Http;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Text;
 
 namespace Maliev.ContactService.Tests.Services;
 
@@ -81,7 +82,8 @@ public sealed class ServiceAuthenticationWiringTests
         configuration["ServiceAuthentication:ClientId"] = "service-contact-service";
         configuration["ServiceAuthentication:ClientSecret"] = "contact-test-secret-with-at-least-32-bytes";
         configuration["Services:AuthService:BaseUrl"] = "http://127.0.0.1:5000";
-        configuration["Jwt:PublicKey"] = Convert.ToBase64String(rsa.ExportSubjectPublicKeyInfo());
+        configuration["Jwt:PublicKey"] = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(rsa.ExportSubjectPublicKeyInfoPem()));
         configuration["Jwt:Issuer"] = "https://api.maliev.com";
         configuration["Jwt:Audience"] = "https://api.maliev.com";
     }


### PR DESCRIPTION
## Summary
- register ContactService for fail-closed AuthService client-credential exchange using the exact code-owned `ContactService` identity
- authenticate UploadService and CountryService typed clients with centrally issued bearer tokens
- remove the unused legacy IAM client registration that exposed the local wildcard-signing provider
- supply Testing-only exchange/trust configuration and add focused wiring/security regressions

## Contract and security
- no route, verb, request DTO, response DTO, or JSON property changes
- unsigned object-storage transfer client remains separate and receives no service bearer token
- production startup now requires valid ContactService credentials, AuthService origin, and JWT public trust metadata

## Validation
- RED: focused regression initially failed 3/4 (missing startup exchange and two legacy downstream handlers)
- GREEN: focused `ServiceAuthenticationWiringTests` 4/4
- GREEN: non-integration suite 56/56
- GREEN: Release build (0 warnings/errors)
- GREEN: `dotnet format --verify-no-changes`
- full local suite: 56 passed; 29 Testcontainers cases infrastructure-blocked by Docker Hub registry timeout before test execution. PR CI is expected to provide clean-container evidence.

Tracking: MALIEV-Co-Ltd/maliev-ops#75, MALIEV-Co-Ltd/maliev-ops#71