### PR TITLE
test: apply current Dependabot test tooling upgrades

### DIFF
--- a/Maliev.ContactService.Tests/Maliev.ContactService.Tests.csproj
+++ b/Maliev.ContactService.Tests/Maliev.ContactService.Tests.csproj
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <!-- Test Framework -->
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.*-*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Respawn" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Outcome
Resolves the remaining conflicted Dependabot test-tooling updates on the current ContactService implementation:
- Microsoft.NET.Test.Sdk 18.8.1 (supersedes #67)
- coverlet.collector 10.0.1 (supersedes #66)

## Validation
- Release build: 0 warnings/errors
- full integration tests: 93/93
- NuGet vulnerability audit: clean
- format verification: clean
- patch gitleaks scan: clean

No production code, deployment workflow, or GitOps state is changed.